### PR TITLE
Fix "lmtp: Error: free(): invalid pointer" if initialization failed

### DIFF
--- a/src/fts-backend-flatcurve.c
+++ b/src/fts-backend-flatcurve.c
@@ -27,7 +27,7 @@ static struct fts_backend *fts_backend_flatcurve_alloc(void)
 
 	pool = pool_alloconly_create(FTS_FLATCURVE_LABEL " pool", 4096);
 
-	backend = p_new(pool, struct flatcurve_fts_backend, 1);
+	backend = i_new(struct flatcurve_fts_backend, 1);
 	backend->backend = fts_backend_flatcurve;
 	backend->pool = pool;
 
@@ -95,6 +95,8 @@ static void fts_backend_flatcurve_deinit(struct fts_backend *_backend)
 
 	event_unref(&backend->event);
 	pool_unref(&backend->pool);
+
+	i_free(backend);
 }
 
 static void


### PR DESCRIPTION
fts_backend_init() in Dovecot core assumes that the FTS backend structure is
allocated by i_new() and uses i_free() to free it if the initialization of the
FTS plugin failed:

int fts_backend_init(const char *backend_name, struct mail_namespace *ns,
                     const char **error_r, struct fts_backend **backend_r)
{
...
        if (backend->v.init(backend, error_r) < 0) {
                i_free(backend);

The FTS Flatcurve plugin allocates the backend structure from a pool using
p_new() instead. This leads to an "lmtp: Error: free(): invalid pointer" error
if the initialization of the plugin failed (e.g. because of invalid or missing
plugin configuration settings) and causes a mail delivery failure.

To reproduce, remove a mandatory plugin configuration setting, e.g
fts_languages.

This commit changes p_new() to i_new() to fix this problem.