### PR TITLE
github actions: Compile plugin from workflow checkout

### DIFF
--- a/.github/actions/dovecot-fts-flatcurve-test/Dockerfile
+++ b/.github/actions/dovecot-fts-flatcurve-test/Dockerfile
@@ -35,9 +35,6 @@ RUN cd /dovecot/core && ./autogen.sh && \
 	PANDOC=false ./configure --with-stemmer --with-textcat --with-icu && \
 	make install
 
-RUN git clone --depth 1 https://github.com/slusarz/dovecot-fts-flatcurve.git /dovecot/fts-flatcurve
-RUN cd /dovecot/fts-flatcurve && ./autogen.sh && ./configure && make install
-
 # Users dovecot and dovenull are created by dovecot-imaptest package
 RUN useradd vmail && \
     mkdir -p /dovecot/sdbox && \

--- a/.github/actions/dovecot-fts-flatcurve-test/entrypoint.sh
+++ b/.github/actions/dovecot-fts-flatcurve-test/entrypoint.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+echo "Compiling plugin"
+./autogen.sh && ./configure && make install
+
 TESTUSER=user
 TESTPASS=pass
 TESTBOX=imaptest


### PR DESCRIPTION
To run the tests against the plugin from the current repository, branch or pull
request, compile it from the workflow checkout