### PR TITLE
doveadm fts-flatcurve: Fix segmentation fault if plugin is loaded but not enabled

### DIFF
--- a/src/doveadm-fts-flatcurve.c
+++ b/src/doveadm-fts-flatcurve.c
@@ -185,7 +185,7 @@ cmd_fts_flatcurve_mailbox_run(struct doveadm_mail_cmd_context *_ctx,
 	struct fts_flatcurve_user *fuser =
 		FTS_FLATCURVE_USER_CONTEXT(user);
 
-	if (fuser == NULL) {
+	if (fuser == NULL || fuser->backend == NULL) {
 		e_error(user->event, FTS_FLATCURVE_LABEL " not enabled");
 		doveadm_mail_failed_error(_ctx, MAIL_ERROR_NOTFOUND);
 		return -1;


### PR DESCRIPTION
`doveadm fts-flatcurve` segfaults if the plugin is loaded but not enabled:

```
mail_plugins = $mail_plugins fts_flatcurve
plugin {
  fts = squat
}

doveadm fts-flatcurve check -u ewald INBOX
Segmentation fault
```

With this patch:

```
doveadm fts-flatcurve check -u ewald INBOX
doveadm(ewald): Error: fts-flatcurve not enabled
```
