### PR TITLE
Skip .nfs files when iterating DBs

### DIFF
--- a/src/fts-backend-flatcurve-xapian.cpp
+++ b/src/fts-backend-flatcurve-xapian.cpp
@@ -302,7 +302,8 @@ fts_flatcurve_xapian_db_iter_next(struct flatcurve_xapian_db_iter *iter)
 	if ((iter->dirp == NULL) || (d = readdir(iter->dirp)) == NULL)
 		return FALSE;
 
-	if ((strcmp(d->d_name, ".") == 0) || (strcmp(d->d_name, "..") == 0))
+	if ((strcmp(d->d_name, ".") == 0) || (strcmp(d->d_name, "..") == 0) ||
+	    str_begins(d->d_name, ".nfs"))
 		return fts_flatcurve_xapian_db_iter_next(iter);
 
 	iter->path = fts_flatcurve_xapian_create_db_path(iter->backend,


### PR DESCRIPTION
This is somehow related to https://github.com/slusarz/dovecot-fts-flatcurve/issues/54 and https://github.com/slusarz/dovecot-fts-flatcurve/pull/55 and only affects NFS mail stores.

Flatcurve adds .nfs files  to the list of DBs with type "unknown". This leads to failures when Flatcurve deletes fts data (e.g. when optimizing the index).

```
Debug: fts-flatcurve(INBOX): Deleting fts data failed file=.../mailboxes/INBOX/dbox-Mails/fts-flatcurve/.nfs000000000008042000000185
```

It's only a debug message and it doesn't break anything, but this patch avoids those messages.
