### PR TITLE
Prevent warning "Could not open mailbox" when iterating mailboxes

### DIFF
--- a/src/fts-backend-flatcurve.c
+++ b/src/fts-backend-flatcurve.c
@@ -494,6 +494,9 @@ fts_backend_flatcurve_iterate_ns(struct fts_backend *_backend,
 
 	iter = mailbox_list_iter_init(_backend->ns->list, "*", iter_flags);
 	while ((info = mailbox_list_iter_next(iter)) != NULL) {
+		if ((info->flags & (MAILBOX_NOSELECT | MAILBOX_NONEXISTENT)) != 0)
+                        continue;
+
 		box = mailbox_alloc(backend->backend.ns->list, info->vname,
 				    mbox_flags);
 		fts_backend_flatcurve_set_mailbox(backend, box);


### PR DESCRIPTION
This patch skips \Noselect and \NonExistent mailboxes to prevent "Could not open mailbox" warnings, e.g. on rescan or optimize:

```
 doveadm mailbox create -u user noselect/sub
 doveadm fts rescan -u user
 doveadm(user): Warning: fts-flatcurve: Could not open mailbox: noselect
```
