### PR TITLE
Fix token maxlen handling and substring indexing crash

### DIFF
--- a/src/fts-backend-flatcurve-xapian.cpp
+++ b/src/fts-backend-flatcurve-xapian.cpp
@@ -1284,7 +1284,7 @@ fts_flatcurve_xapian_index_header(struct flatcurve_fts_backend_update_context *c
 		size -= csize;
 	} while (fuser->set.substring_search &&
 		(size >= 0) &&
-		(uni_utf8_strlen(p) >= fuser->set.min_term_size));
+		(uni_utf8_strlen_n(p, size) >= fuser->set.min_term_size));
 }
 
 void
@@ -1315,7 +1315,7 @@ fts_flatcurve_xapian_index_body(struct flatcurve_fts_backend_update_context *ctx
 		size -= csize;
 	} while (fuser->set.substring_search &&
 		(size >= 0) &&
-		(uni_utf8_strlen(p) >= fuser->set.min_term_size));
+		(uni_utf8_strlen_n(p, size) >= fuser->set.min_term_size));
 }
 
 void fts_flatcurve_xapian_delete_index(struct flatcurve_fts_backend *backend)

--- a/src/fts-backend-flatcurve.c
+++ b/src/fts-backend-flatcurve.c
@@ -316,7 +316,7 @@ fts_backend_flatcurve_update_build_more(struct fts_backend_update_context *_ctx,
 
 	/* Xapian has a hard limit of "245 bytes", at least with the glass
 	 * and chert backends. */
-	size = I_MIN(size, FTS_FLATCURVE_MAX_TERM_SIZE);
+	(void)uni_utf8_partial_strlen_n(data, I_MIN(size, FTS_FLATCURVE_MAX_TERM_SIZE), &size);
 
 	switch (ctx->type) {
 	case FTS_BACKEND_BUILD_KEY_HDR:


### PR DESCRIPTION
This is my attempt to fix the problems that I described in https://github.com/slusarz/dovecot-fts-flatcurve/issues/62#issuecomment-2178894698.

1. Don't split multi-byte characters when enforcing FTS_FLATCURVE_MAX_TERM_SIZE (either because of the apparently buggy generic tokenizer, see https://github.com/slusarz/dovecot-fts-flatcurve/issues/62#issuecomment-2178894698 or because the tokenizer's maxlen is larger than FTS_FLATCURVE_MAX_TERM_SIZE , e.g. `fts_tokenizer_generic = maxlen=250`)
2. Fix a crash when doing substring indexing (`fts_flatcurve_substring_search = yes`) because the do/while loop might be executed with `size == 0` leading to an unsigned integer underflow.
