### PR TITLE
Fix memory leak in fts_flatcurve_xapian_query_iter_next()

### DIFF
--- a/src/fts-backend-flatcurve-xapian.cpp
+++ b/src/fts-backend-flatcurve-xapian.cpp
@@ -1794,6 +1794,7 @@ fts_flatcurve_xapian_query_iter_deinit(struct fts_flatcurve_xapian_query_iter **
 	 * allocated internally. */
 	*_iter = NULL;
 	iter->i.~MSetIterator();
+	iter->m.~MSet();
 	delete(iter->enquire);
 	p_free(iter->query->pool, iter->result);
 	p_free(iter->query->pool, iter);


### PR DESCRIPTION
This patch fixes a memory leak in `fts_flatcurve_xapian_query_iter_next()`.

valgrind:

```
==29989== 39,883 (256 direct, 39,627 indirect) bytes in 1 blocks are definitely lost in loss record 42 of 43
==29989==    at 0x4840F2F: operator new(unsigned long) (vg_replace_malloc.c:422)
==29989==    by 0x7E8B2B0: ??? (in /usr/lib/x86_64-linux-gnu/libxapian.so.30.12.3)
==29989==    by 0x7D930FD: Xapian::Enquire::Internal::get_mset(unsigned int, unsigned int, unsigned int, Xapian::RSet const*, Xapian::MatchDecider const*) const (in /usr/lib/x86_64-linux-gnu/libxapian.so.30.12.3)
==29989==    by 0x7D93363: Xapian::Enquire::get_mset(unsigned int, unsigned int, unsigned int, Xapian::RSet const*, Xapian::MatchDecider const*) const (in /usr/lib/x86_64-linux-gnu/libxapian.so.30.12.3)
==29989==    by 0x55940C4: fts_flatcurve_xapian_query_iter_next (fts-backend-flatcurve-xapian.cpp:1752)
==29989==    by 0x559457A: fts_flatcurve_xapian_run_query (fts-backend-flatcurve-xapian.cpp:1811)
==29989==    by 0x558DB9B: fts_backend_flatcurve_lookup_multi (fts-backend-flatcurve.c:593)
==29989==    by 0x558DEFA: fts_backend_flatcurve_lookup (fts-backend-flatcurve.c:652)
==29989==    by 0x536B35C: fts_backend_lookup (fts-api.c:377)
==29989==    by 0x5370156: fts_search_lookup_level_single (fts-search.c:53)
==29989==    by 0x5370156: fts_search_lookup_level (fts-search.c:216)
==29989==    by 0x53708EB: fts_search_try_lookup (fts-search.c:371)
==29989==    by 0x53708EB: fts_search_lookup (fts-search.c:383)
==29989==    by 0x53734CF: fts_mailbox_search_init (fts-storage.c:264)
```

